### PR TITLE
병렬트랜잭션에서 등록될 때 연관관계의 부모가 삭제되는 경우 확인해보기

### DIFF
--- a/spring-data-jpa/src/main/java/study/spring/jpa/model/Category.java
+++ b/spring-data-jpa/src/main/java/study/spring/jpa/model/Category.java
@@ -1,0 +1,54 @@
+package study.spring.jpa.model;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "category")
+@Entity
+public class Category {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(targetEntity = Category.class, fetch = FetchType.LAZY, cascade = CascadeType.DETACH)
+    @JoinColumn(name = "parent_id")
+    private Category parentCategory;
+
+    public Category(String name, Category parentCategory) {
+        this.name = name;
+        this.parentCategory = parentCategory;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        Category category = (Category) o;
+        return id != null && Objects.equals(id, category.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Category{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/spring-data-jpa/src/main/java/study/spring/jpa/model/CategoryRepository.java
+++ b/spring-data-jpa/src/main/java/study/spring/jpa/model/CategoryRepository.java
@@ -1,0 +1,6 @@
+package study.spring.jpa.model;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/spring-data-jpa/src/main/java/study/spring/jpa/model/CategoryService.java
+++ b/spring-data-jpa/src/main/java/study/spring/jpa/model/CategoryService.java
@@ -1,0 +1,43 @@
+package study.spring.jpa.model;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+@Slf4j
+@Service
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        log.info("[delete] 시작");
+        categoryRepository.deleteById(id);
+        log.info("[delete] 끝");
+    }
+
+    @Transactional
+    public void create(String name, Long parentId) {
+        log.info("[create] 시작");
+        Category parentCategory = categoryRepository.findById(parentId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        Category category = new Category(name, parentCategory);
+
+        categoryRepository.save(category);
+        log.info("카테고리 저장완료");
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        log.info("[create] 끝");
+    }
+}

--- a/spring-data-jpa/src/test/java/study/spring/jpa/model/CategoryServiceTest.java
+++ b/spring-data-jpa/src/test/java/study/spring/jpa/model/CategoryServiceTest.java
@@ -1,0 +1,59 @@
+package study.spring.jpa.model;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@SpringBootTest
+class CategoryServiceTest {
+
+    @Autowired
+    private CategoryService categoryService;
+    
+    @Autowired
+    private CategoryRepository categoryRepository;
+    private Long PARENT_CATEGORY_ID;
+    
+    @BeforeEach
+    void init() {
+        Category parentCategory = categoryRepository.saveAndFlush(new Category("부모카테고리", null));
+        PARENT_CATEGORY_ID = parentCategory.getId();
+    }
+
+    @Test
+    void test() {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        // 자식 등록
+        executorService.execute(() -> {
+            categoryService.create("자식카테고리", PARENT_CATEGORY_ID);
+        });
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        // 부모 삭제
+        executorService.execute(() -> {
+            categoryService.delete(PARENT_CATEGORY_ID);
+        });
+
+        try {
+            Thread.sleep(4000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        List<Category> categories = categoryRepository.findAll();
+        log.info("categories: " + categories);
+    }
+}


### PR DESCRIPTION
- 트랜잭션-1: 부모A를 가진 카테고리B 등록
- 트랜잭션-2: 부모A 삭제

두 트랜잭션이 병렬적으로 발생할 때 외래키 문제로 에러가 발생함.  
등록 먼저 된 후 삭제하면? 외래키가 걸려있어서 삭제할 수 없음  
삭제 먼저 된 후 등록하면? 외래키에 걸린 값이 삭제되어서 연관관계가 불가함