### PR TITLE
spring-event: 별도의 트랜잭션, 별도의 스레드로 동작하기

### DIFF
--- a/spring-event/src/main/java/com/study/springevent/SpringEventApplication.java
+++ b/spring-event/src/main/java/com/study/springevent/SpringEventApplication.java
@@ -2,7 +2,9 @@ package com.study.springevent;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class SpringEventApplication {
 

--- a/spring-event/src/main/java/com/study/springevent/domain/cart/domain/DeleteCartWithOrderEventHandler.java
+++ b/spring-event/src/main/java/com/study/springevent/domain/cart/domain/DeleteCartWithOrderEventHandler.java
@@ -5,7 +5,11 @@ import com.study.springevent.domain.order.domain.OrderEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
@@ -25,7 +29,9 @@ public class DeleteCartWithOrderEventHandler {
      * @EventListener 는 이벤트 전파가 가능하지만, @TransactionalEventListener 는 전파가 불가하다고 한다.
      * 해당 코드가 어떻게 내부적으로 동작하는지 확인 할 필요가 있다.
      * */
-    @TransactionalEventListener
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deleteCartRecode(OrderEvent event) {
         log.info("장바구니삭제 event listener handle 실행 - 2");
     }


### PR DESCRIPTION
## 별도의 트랜잭션

### 문제: 리스너는 transaction commit 이후의 상태이다.
`@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)` 를 통해 발행하는 곳의 트랜잭션이 commit 된 후 리스너를 수행하도록 하였다.
위의 어노테이션으로는 **트랜잭션이 commit된 상태일 뿐 종료된 상태가 아니다.**
즉, 리스너 쪽에서는 트랜직션이 commit된 이후이기 때문에 insert/update/delete가 불가하다.

### 해결: 트랜잭션 생성

`@Transactional(propagation = Propagation.REQUIRES_NEW)` 어노테이션으로 트랜잭션을 새로 생성하면 된다.

## 별도의 스레드

### 문제: 트랜잭션은 분리했지만 하나의 스레드

스레드와 트랜잭션은 다르다. 별도의 트랜잭션이 2개가 수행되지만 하나의 스레드로 동작한다. (로그를 보면 스레드 이름이 같음)
리스너의 업무가 끝날 때 까지 스레드는 함께 동작한다. 애초에 분리하는 것을 목적으로 하고 있는데 계속 연결되어있는 것.

### 해결: 비동기

[스프링 가이드 참고](https://spring.io/guides/gs/async-method/)

1.  메인클래스에 어노테이션 추가

```java
import org.springframework.scheduling.annotation.EnableAsync;

@EnableAsync // 어노테이션 추가!
@SpringBootApplication
public class SpringEventApplication {
// 중략
}
```
2. 리스너 메소드에 `@Async` 어노테이션 추가

## 마무리

이벤트를 완전히 분리함으로써 결합도를 낮췄다.
하지만 정말 완벽히 분리해도 되는 로직인지 다시 한번 고민해봐야한다.
또한 코드 추적의 복잡도가 올라갔고 리스너 에러에 대한 복구 방안도 함께 고민하고 적용해야한다.
